### PR TITLE
build.gradle.kts under buildSrc/**/buildSrc are broken for branch agp-7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,4 @@ The agp-7.0 branch currently represents the state of AGP 7.0
     See the License for the specific language governing permissions and
     limitations under the License.
     
+dummy changes


### PR DESCRIPTION
I am sorry to make this meaningless PR since I don't find any other method to notify this problem. I am trying to lean new AGP API from the recipes, but found that all `build.gradle.kts` files under `<repoRoot>/buildSrc/**/buildSrc`` are broken. Please ignore this PR and update the source.

PS: why not open the issue or discussion feature on GitHub to let community talks to each other?