### PR TITLE
Remove nonTransitiveRClass flags

### DIFF
--- a/recipes/addBuildTypeUsingDslFinalize/gradle.properties
+++ b/recipes/addBuildTypeUsingDslFinalize/gradle.properties
@@ -17,7 +17,3 @@ org.gradle.parallel=true
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-# Enables namespacing of each library's R class so that its R class includes only the
-# resources declared in the library itself and none from the library's dependencies,
-# thereby reducing the size of the R class for that library
-android.nonTransitiveRClass=true

--- a/recipes/addCustomBuildConfigFields/gradle.properties
+++ b/recipes/addCustomBuildConfigFields/gradle.properties
@@ -17,7 +17,3 @@ org.gradle.parallel=true
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-# Enables namespacing of each library's R class so that its R class includes only the
-# resources declared in the library itself and none from the library's dependencies,
-# thereby reducing the size of the R class for that library
-android.nonTransitiveRClass=true

--- a/recipes/addCustomSourceType/gradle.properties
+++ b/recipes/addCustomSourceType/gradle.properties
@@ -17,7 +17,3 @@ org.gradle.parallel=true
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-# Enables namespacing of each library's R class so that its R class includes only the
-# resources declared in the library itself and none from the library's dependencies,
-# thereby reducing the size of the R class for that library
-android.nonTransitiveRClass=true

--- a/recipes/addGeneratedSourceFolder/gradle.properties
+++ b/recipes/addGeneratedSourceFolder/gradle.properties
@@ -17,7 +17,3 @@ org.gradle.parallel=true
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-# Enables namespacing of each library's R class so that its R class includes only the
-# resources declared in the library itself and none from the library's dependencies,
-# thereby reducing the size of the R class for that library
-android.nonTransitiveRClass=true

--- a/recipes/addMultipleArtifact/gradle.properties
+++ b/recipes/addMultipleArtifact/gradle.properties
@@ -17,7 +17,3 @@ org.gradle.parallel=true
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-# Enables namespacing of each library's R class so that its R class includes only the
-# resources declared in the library itself and none from the library's dependencies,
-# thereby reducing the size of the R class for that library
-android.nonTransitiveRClass=true

--- a/recipes/allProjectsApkAction/gradle.properties
+++ b/recipes/allProjectsApkAction/gradle.properties
@@ -17,7 +17,3 @@ org.gradle.parallel=true
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-# Enables namespacing of each library's R class so that its R class includes only the
-# resources declared in the library itself and none from the library's dependencies,
-# thereby reducing the size of the R class for that library
-android.nonTransitiveRClass=true

--- a/recipes/appendToMultipleArtifact/gradle.properties
+++ b/recipes/appendToMultipleArtifact/gradle.properties
@@ -17,7 +17,3 @@ org.gradle.parallel=true
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-# Enables namespacing of each library's R class so that its R class includes only the
-# resources declared in the library itself and none from the library's dependencies,
-# thereby reducing the size of the R class for that library
-android.nonTransitiveRClass=true

--- a/recipes/appendToScopedArtifacts/gradle.properties
+++ b/recipes/appendToScopedArtifacts/gradle.properties
@@ -17,7 +17,3 @@ org.gradle.parallel=true
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-# Enables namespacing of each library's R class so that its R class includes only the
-# resources declared in the library itself and none from the library's dependencies,
-# thereby reducing the size of the R class for that library
-android.nonTransitiveRClass=true

--- a/recipes/applyFusedLibraryPlugin/gradle.properties
+++ b/recipes/applyFusedLibraryPlugin/gradle.properties
@@ -17,10 +17,6 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-# Enables namespacing of each library's R class so that its R class includes only the
-# resources declared in the library itself and none from the library's dependencies,
-# thereby reducing the size of the R class for that library
-android.nonTransitiveRClass=true
 
 # Required for builds with at least one module applying
 # the experimental "com.android.fused-library" plugin.

--- a/recipes/asmTransformClasses/gradle.properties
+++ b/recipes/asmTransformClasses/gradle.properties
@@ -17,7 +17,3 @@ org.gradle.parallel=true
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-# Enables namespacing of each library's R class so that its R class includes only the
-# resources declared in the library itself and none from the library's dependencies,
-# thereby reducing the size of the R class for that library
-android.nonTransitiveRClass=true

--- a/recipes/createSingleArtifact/gradle.properties
+++ b/recipes/createSingleArtifact/gradle.properties
@@ -17,7 +17,3 @@ org.gradle.parallel=true
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-# Enables namespacing of each library's R class so that its R class includes only the
-# resources declared in the library itself and none from the library's dependencies,
-# thereby reducing the size of the R class for that library
-android.nonTransitiveRClass=true

--- a/recipes/disableTests/gradle.properties
+++ b/recipes/disableTests/gradle.properties
@@ -17,7 +17,3 @@ org.gradle.parallel=true
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-# Enables namespacing of each library's R class so that its R class includes only the
-# resources declared in the library itself and none from the library's dependencies,
-# thereby reducing the size of the R class for that library
-android.nonTransitiveRClass=true

--- a/recipes/extendingAgp/gradle.properties
+++ b/recipes/extendingAgp/gradle.properties
@@ -17,7 +17,3 @@ org.gradle.parallel=true
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-# Enables namespacing of each library's R class so that its R class includes only the
-# resources declared in the library itself and none from the library's dependencies,
-# thereby reducing the size of the R class for that library
-android.nonTransitiveRClass=true

--- a/recipes/getMultipleArtifact/gradle.properties
+++ b/recipes/getMultipleArtifact/gradle.properties
@@ -17,7 +17,3 @@ org.gradle.parallel=true
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-# Enables namespacing of each library's R class so that its R class includes only the
-# resources declared in the library itself and none from the library's dependencies,
-# thereby reducing the size of the R class for that library
-android.nonTransitiveRClass=true

--- a/recipes/getScopedArtifacts/gradle.properties
+++ b/recipes/getScopedArtifacts/gradle.properties
@@ -17,7 +17,3 @@ org.gradle.parallel=true
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-# Enables namespacing of each library's R class so that its R class includes only the
-# resources declared in the library itself and none from the library's dependencies,
-# thereby reducing the size of the R class for that library
-android.nonTransitiveRClass=true

--- a/recipes/getSingleArtifact/gradle.properties
+++ b/recipes/getSingleArtifact/gradle.properties
@@ -17,7 +17,3 @@ org.gradle.parallel=true
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-# Enables namespacing of each library's R class so that its R class includes only the
-# resources declared in the library itself and none from the library's dependencies,
-# thereby reducing the size of the R class for that library
-android.nonTransitiveRClass=true

--- a/recipes/legacyTaskBridging/gradle.properties
+++ b/recipes/legacyTaskBridging/gradle.properties
@@ -17,7 +17,3 @@ org.gradle.parallel=true
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-# Enables namespacing of each library's R class so that its R class includes only the
-# resources declared in the library itself and none from the library's dependencies,
-# thereby reducing the size of the R class for that library
-android.nonTransitiveRClass=true

--- a/recipes/listenToArtifacts/gradle.properties
+++ b/recipes/listenToArtifacts/gradle.properties
@@ -17,7 +17,3 @@ org.gradle.parallel=true
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-# Enables namespacing of each library's R class so that its R class includes only the
-# resources declared in the library itself and none from the library's dependencies,
-# thereby reducing the size of the R class for that library
-android.nonTransitiveRClass=true

--- a/recipes/listenToMultipleArtifact/gradle.properties
+++ b/recipes/listenToMultipleArtifact/gradle.properties
@@ -17,7 +17,3 @@ org.gradle.parallel=true
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-# Enables namespacing of each library's R class so that its R class includes only the
-# resources declared in the library itself and none from the library's dependencies,
-# thereby reducing the size of the R class for that library
-android.nonTransitiveRClass=true

--- a/recipes/onVariants/gradle.properties
+++ b/recipes/onVariants/gradle.properties
@@ -17,7 +17,3 @@ org.gradle.parallel=true
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-# Enables namespacing of each library's R class so that its R class includes only the
-# resources declared in the library itself and none from the library's dependencies,
-# thereby reducing the size of the R class for that library
-android.nonTransitiveRClass=true

--- a/recipes/perVariantManifestPlaceholder/gradle.properties
+++ b/recipes/perVariantManifestPlaceholder/gradle.properties
@@ -17,7 +17,3 @@ org.gradle.parallel=true
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-# Enables namespacing of each library's R class so that its R class includes only the
-# resources declared in the library itself and none from the library's dependencies,
-# thereby reducing the size of the R class for that library
-android.nonTransitiveRClass=true

--- a/recipes/registerPreBuild/gradle.properties
+++ b/recipes/registerPreBuild/gradle.properties
@@ -17,7 +17,3 @@ org.gradle.parallel=true
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-# Enables namespacing of each library's R class so that its R class includes only the
-# resources declared in the library itself and none from the library's dependencies,
-# thereby reducing the size of the R class for that library
-android.nonTransitiveRClass=true

--- a/recipes/selectVariants/gradle.properties
+++ b/recipes/selectVariants/gradle.properties
@@ -17,7 +17,3 @@ org.gradle.parallel=true
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-# Enables namespacing of each library's R class so that its R class includes only the
-# resources declared in the library itself and none from the library's dependencies,
-# thereby reducing the size of the R class for that library
-android.nonTransitiveRClass=true

--- a/recipes/testFixtures/gradle.properties
+++ b/recipes/testFixtures/gradle.properties
@@ -17,7 +17,3 @@ org.gradle.parallel=true
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-# Enables namespacing of each library's R class so that its R class includes only the
-# resources declared in the library itself and none from the library's dependencies,
-# thereby reducing the size of the R class for that library
-android.nonTransitiveRClass=true

--- a/recipes/transformAllClasses/gradle.properties
+++ b/recipes/transformAllClasses/gradle.properties
@@ -17,7 +17,3 @@ org.gradle.parallel=true
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-# Enables namespacing of each library's R class so that its R class includes only the
-# resources declared in the library itself and none from the library's dependencies,
-# thereby reducing the size of the R class for that library
-android.nonTransitiveRClass=true

--- a/recipes/transformDirectory/gradle.properties
+++ b/recipes/transformDirectory/gradle.properties
@@ -17,7 +17,3 @@ org.gradle.parallel=true
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-# Enables namespacing of each library's R class so that its R class includes only the
-# resources declared in the library itself and none from the library's dependencies,
-# thereby reducing the size of the R class for that library
-android.nonTransitiveRClass=true

--- a/recipes/transformManifest/gradle.properties
+++ b/recipes/transformManifest/gradle.properties
@@ -17,7 +17,3 @@ org.gradle.parallel=true
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-# Enables namespacing of each library's R class so that its R class includes only the
-# resources declared in the library itself and none from the library's dependencies,
-# thereby reducing the size of the R class for that library
-android.nonTransitiveRClass=true

--- a/recipes/transformMultiple/gradle.properties
+++ b/recipes/transformMultiple/gradle.properties
@@ -17,7 +17,3 @@ org.gradle.parallel=true
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-# Enables namespacing of each library's R class so that its R class includes only the
-# resources declared in the library itself and none from the library's dependencies,
-# thereby reducing the size of the R class for that library
-android.nonTransitiveRClass=true

--- a/recipes/variantDependencySubstitutionTest/gradle.properties
+++ b/recipes/variantDependencySubstitutionTest/gradle.properties
@@ -17,7 +17,3 @@ org.gradle.parallel=true
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-# Enables namespacing of each library's R class so that its R class includes only the
-# resources declared in the library itself and none from the library's dependencies,
-# thereby reducing the size of the R class for that library
-android.nonTransitiveRClass=true

--- a/recipes/variantOutput/gradle.properties
+++ b/recipes/variantOutput/gradle.properties
@@ -17,7 +17,3 @@ org.gradle.parallel=true
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-# Enables namespacing of each library's R class so that its R class includes only the
-# resources declared in the library itself and none from the library's dependencies,
-# thereby reducing the size of the R class for that library
-android.nonTransitiveRClass=true

--- a/recipes/workerEnabledTransformation/gradle.properties
+++ b/recipes/workerEnabledTransformation/gradle.properties
@@ -17,7 +17,3 @@ org.gradle.parallel=true
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-# Enables namespacing of each library's R class so that its R class includes only the
-# resources declared in the library itself and none from the library's dependencies,
-# thereby reducing the size of the R class for that library
-android.nonTransitiveRClass=true

--- a/templates/TemplateRecipe/gradle.properties
+++ b/templates/TemplateRecipe/gradle.properties
@@ -17,7 +17,3 @@ org.gradle.parallel=true
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-# Enables namespacing of each library's R class so that its R class includes only the
-# resources declared in the library itself and none from the library's dependencies,
-# thereby reducing the size of the R class for that library
-android.nonTransitiveRClass=true

--- a/templates/TemplateSettingsRecipe/gradle.properties
+++ b/templates/TemplateSettingsRecipe/gradle.properties
@@ -17,7 +17,3 @@ org.gradle.parallel=true
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-# Enables namespacing of each library's R class so that its R class includes only the
-# resources declared in the library itself and none from the library's dependencies,
-# thereby reducing the size of the R class for that library
-android.nonTransitiveRClass=true


### PR DESCRIPTION
It's the default from AGP 8.0, see https://developer.android.com/build/releases/past-releases/agp-8-0-0-release-notes#default-changes