### PR TITLE
Enable and introduce kotlin test fixtures

### DIFF
--- a/recipes/testFixtures/README.md
+++ b/recipes/testFixtures/README.md
@@ -26,7 +26,7 @@ Test dependency must be declared in Gradle script to target the fixture artifact
 
 You can check details of logic we test in [ViewModel](app/src/main/kotlin/ViewModel.kt),
 test itself in [ViewModelTest](app/src/test/kotlin/ViewModelTest.kt) and 
-fixture [UserRepoFixture](lib/src/testFixtures/java/UserRepoFixture.java).
+fixture [JavaUserRepoFixture](lib/src/testFixtures/java/JavaUserRepoFixture.java).
 
 ## To Run
 To execute example and run tests you need to enter command:

--- a/recipes/testFixtures/README.md
+++ b/recipes/testFixtures/README.md
@@ -4,7 +4,8 @@ This recipe shows how to use test fixtures with Android projects.
 
 ---
 
-**Be Aware:** we don't support writing test-fixtures in Kotlin for AGP versions up to 8.4, only Java
+**Be Aware:** we don't support writing test-fixtures in Kotlin for AGP versions up to 8.4, only Java.
+Kotlin test fixtures are supported from AGP 8.5 and later.
 
 ---
 Recipe has the following module structure:
@@ -26,7 +27,8 @@ Test dependency must be declared in Gradle script to target the fixture artifact
 
 You can check details of logic we test in [ViewModel](app/src/main/kotlin/ViewModel.kt),
 test itself in [ViewModelTest](app/src/test/kotlin/ViewModelTest.kt) and 
-fixture [JavaUserRepoFixture](lib/src/testFixtures/java/JavaUserRepoFixture.java).
+fixture using Java [JavaUserRepoFixture](lib/src/testFixtures/java/JavaUserRepoFixture.java) or 
+fixture using Kotlin [KotlinUserRepoFixture](lib/src/testFixtures/java/KotlinUserRepoFixture.kt).
 
 ## To Run
 To execute example and run tests you need to enter command:

--- a/recipes/testFixtures/app/src/test/kotlin/ViewModelTest.kt
+++ b/recipes/testFixtures/app/src/test/kotlin/ViewModelTest.kt
@@ -31,4 +31,15 @@ class ViewModelTest{
         fixture.inDataSet(user)
         fixture.assertEventIsUpdateUser(model.getEvents()[0])
     }
+
+    @Test
+    fun updateUserKotlinLogic(){
+        val fixture = KotlinUserRepoFixture()
+        val model = ViewModel(fixture.repository)
+        val user = model.users[0].copy(status = "sick")
+        model.updateStatus(user.id, user.status)
+
+        fixture.inDataSet(user)
+        fixture.assertEventIsUpdateUser(model.getEvents()[0])
+    }
 }

--- a/recipes/testFixtures/app/src/test/kotlin/ViewModelTest.kt
+++ b/recipes/testFixtures/app/src/test/kotlin/ViewModelTest.kt
@@ -23,7 +23,7 @@ class ViewModelTest{
 
     @Test
     fun updateUserLogic(){
-        val fixture = UserRepoFixture()
+        val fixture = JavaUserRepoFixture()
         val model = ViewModel(fixture.getRepository())
         val user = model.users[0].copy(status = "sick")
         model.updateStatus(user.id, user.status)

--- a/recipes/testFixtures/gradle.properties
+++ b/recipes/testFixtures/gradle.properties
@@ -21,6 +21,5 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-# Enbale test kotlin fixtures
-# Can't find official documentation https://emartynov.medium.com/android-project-test-fixtures-dec50c5d8533
+# Enable test kotlin fixtures
 android.experimental.enableTestFixturesKotlinSupport=true

--- a/recipes/testFixtures/gradle.properties
+++ b/recipes/testFixtures/gradle.properties
@@ -21,3 +21,6 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+# Enbale test kotlin fixtures
+# Can't find official documentation https://emartynov.medium.com/android-project-test-fixtures-dec50c5d8533
+android.experimental.enableTestFixturesKotlinSupport=true

--- a/recipes/testFixtures/lib/src/testFixtures/java/JavaUserRepoFixture.java
+++ b/recipes/testFixtures/lib/src/testFixtures/java/JavaUserRepoFixture.java
@@ -20,11 +20,11 @@ import java.util.Map;
 import java.util.HashMap;
 import java.util.ArrayList;
 
-public class UserRepoFixture {
+public class JavaUserRepoFixture {
 
     private Map<Integer, User> users;
 
-    public UserRepoFixture() {
+    public JavaUserRepoFixture() {
         users = new HashMap<>();
         users.put(1, new User(1, "Bob", "Wilson", "active"));
         users.put(2, new User(2, "John", "Johnson", "vacation"));

--- a/recipes/testFixtures/lib/src/testFixtures/java/KotlinUserRepoFixture.kt
+++ b/recipes/testFixtures/lib/src/testFixtures/java/KotlinUserRepoFixture.kt
@@ -1,0 +1,45 @@
+import com.google.common.truth.Truth
+
+import com.example.android.recipes.fixtureLib.R as AppR
+
+class KotlinUserRepoFixture {
+    private val users: MutableMap<Int, User> =
+        HashMap()
+
+    init {
+        users[1] = User(1, "Bob", "Wilson", "active")
+        users[2] = User(2, "John", "Johnson", "vacation")
+    }
+
+    val repository: UserRepository
+        get() = object : UserRepository {
+            private val events: MutableList<Int> =
+                ArrayList()
+
+            override fun getUsers(): List<User> {
+                return ArrayList(users.values)
+            }
+
+            override fun updateUser(user: User) {
+                users[user.id] = user
+                events.add(AppR.string.userUpdated)
+            }
+
+            override fun getUserEvents(): List<Int> {
+                return ArrayList(events)
+            }
+        }
+
+    fun getUsers(): List<User> {
+        return ArrayList(users.values)
+    }
+
+    fun inDataSet(user: User) {
+        Truth.assertThat(users[user.id]).isEqualTo(user)
+    }
+
+    fun assertEventIsUpdateUser(event: Int) {
+        Truth.assertThat(event)
+            .isEqualTo(AppR.string.userUpdated)
+    }
+}


### PR DESCRIPTION
I found the snippet only for Java test fixtures. However, I believe the majority of projects are using Kotlin, and there will be a high demand for test fixtures written in Kotlin.

Updating snippet for Kotlin variant of test fixtures.